### PR TITLE
feat: 가게 상품 생성 API 구현

### DIFF
--- a/src/main/java/com/example/ganzi6/api/center/productCreate/ProductCreateController.java
+++ b/src/main/java/com/example/ganzi6/api/center/productCreate/ProductCreateController.java
@@ -1,0 +1,23 @@
+package com.example.ganzi6.api.center.productCreate;
+
+import com.example.ganzi6.api.center.productCreate.dto.ProductCreateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/markets")
+public class ProductCreateController {
+    private final ProductCreateService productCreateService;
+
+    @PreAuthorize("hasRole('MARKET')")
+    @PostMapping("/{marketId}/products")
+    public ResponseEntity<?> createProduct(@PathVariable Long marketId,
+                                           @RequestBody ProductCreateRequest request) {
+        productCreateService.createProduct(marketId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/example/ganzi6/api/center/productCreate/ProductCreateService.java
+++ b/src/main/java/com/example/ganzi6/api/center/productCreate/ProductCreateService.java
@@ -1,0 +1,46 @@
+package com.example.ganzi6.api.center.productCreate;
+
+import com.example.ganzi6.api.center.productCreate.dto.ProductCreateRequest;
+import com.example.ganzi6.domain.market.Market.Market;
+import com.example.ganzi6.domain.market.MarketRepository.MarketRepository;
+import com.example.ganzi6.domain.product.Product;
+import com.example.ganzi6.domain.product.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ProductCreateService {
+    private final ProductRepository productRepository;
+    private final MarketRepository marketRepository;
+
+    public Long createProduct(Long marketId, ProductCreateRequest request) {
+
+        // 1) Market 조회
+        Market market = marketRepository.findById(marketId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 가게가 존재하지 않습니다."));
+
+        // 2) endTime 변환 (String → LocalDateTime)
+        LocalDateTime endTime = LocalDateTime.parse(request.getEndTime());
+
+        // 3) Product 엔티티 생성
+        Product product = Product.builder()
+                .market(market)
+                .center(null)// 가게가 등록하는 거라 center는 null
+                .name(request.getName())
+                .description(request.getDescription())
+                .endTime(endTime)
+                .count(request.getCount())
+                .imageUrl(request.getImageUrl())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        // 4) DB 저장
+        productRepository.save(product);
+
+        return product.getId();
+    }
+}

--- a/src/main/java/com/example/ganzi6/api/center/productCreate/dto/ProductCreateRequest.java
+++ b/src/main/java/com/example/ganzi6/api/center/productCreate/dto/ProductCreateRequest.java
@@ -1,0 +1,16 @@
+package com.example.ganzi6.api.center.productCreate.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductCreateRequest {
+    private String name;// 음식명
+    private String description;
+    private Integer count;// 수량
+    private String endTime;// String으로 받고 서비스에서 LocalDateTime 변환
+    private String imageUrl;
+}

--- a/src/main/java/com/example/ganzi6/domain/center/Center/Center.java
+++ b/src/main/java/com/example/ganzi6/domain/center/Center/Center.java
@@ -1,10 +1,13 @@
 package com.example.ganzi6.domain.center.Center;
 
+import com.example.ganzi6.domain.product.Product;
 import com.example.ganzi6.domain.user.User.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,5 +31,8 @@ public class Center {
     @OneToOne
     @JoinColumn(name = "user_id", unique = true)
     private User user;
+
+    @OneToMany(mappedBy = "center", cascade = CascadeType.ALL, orphanRemoval = false)
+    private List<Product> products = new ArrayList<>();
 }
 

--- a/src/main/java/com/example/ganzi6/domain/market/Market/Market.java
+++ b/src/main/java/com/example/ganzi6/domain/market/Market/Market.java
@@ -1,10 +1,13 @@
 package com.example.ganzi6.domain.market.Market;
 
+import com.example.ganzi6.domain.product.Product;
 import com.example.ganzi6.domain.user.User.User;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -28,4 +31,7 @@ public class Market {
     @OneToOne
     @JoinColumn(name = "user_id", unique = true)
     private User user;
+
+    @OneToMany(mappedBy = "market", cascade = CascadeType.ALL, orphanRemoval = false)
+    private List<Product> products = new ArrayList<>();
 }

--- a/src/main/java/com/example/ganzi6/domain/product/Product.java
+++ b/src/main/java/com/example/ganzi6/domain/product/Product.java
@@ -1,0 +1,54 @@
+package com.example.ganzi6.domain.product;
+import java.time.LocalDateTime;
+
+import com.example.ganzi6.domain.center.Center.Center;
+import com.example.ganzi6.domain.market.Market.Market;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "product")
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_id")//가게에서 등록한 상품일 때 사용
+    private Market market;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "center_id")
+    private Center center;
+
+
+    @Column(name = "name", nullable = false, length = 100)// 음식명
+    private String name;
+
+    @Column(name = "description", length = 1000)
+    private String description;
+
+    @Column(name = "end_time", nullable = false)//마감 기한
+    private LocalDateTime endTime;
+
+    @Column(name = "count", nullable = false)//수량
+    private Integer count;
+
+    @Column(name = "image_url", length = 1000)
+    private String imageUrl;
+
+
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/ganzi6/domain/product/ProductRepository.java
+++ b/src/main/java/com/example/ganzi6/domain/product/ProductRepository.java
@@ -1,0 +1,26 @@
+package com.example.ganzi6.domain.product;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+    // 1) 특정 가게(Market)가 등록한 전체 상품 목록 조회
+    //    - 가게 마이페이지: 내가 올린 음식 리스트 확인 용도
+    List<Product> findByMarketId(Long marketId);
+
+    // 2) 특정 센터(Center)가 등록한 전체 상품 목록 조회
+    //    - 복지센터/기관이 등록한 상품 조회
+    List<Product> findByCenterId(Long centerId);
+
+    // 3) 가게 기준 + 아직 마감되지 않은 상품만 조회 (endTime > now)
+    //    - 사용자 홈에서 "현재 수령 가능한 음식" 보여줄 때 사용 가능
+    List<Product> findByMarketIdAndEndTimeAfterOrderByEndTimeAsc(Long marketId, LocalDateTime now);
+
+    // 4) 센터 기준 + 아직 마감되지 않은 상품만 조회
+    List<Product> findByCenterIdAndEndTimeAfterOrderByEndTimeAsc(Long centerId, LocalDateTime now);
+
+}


### PR DESCRIPTION
## 📌 작업 내용
- Product(상품) 엔티티 생성 및 ERD 기반 필드 구성
- Market / Center 엔티티와 연관관계 설정
- 상품 등록 API 구현 (가게(MARKET) 계정 전용)
- 상품 생성 서비스/컨트롤러/레포지토리 구현
- Postman 인증 후 상품 등록 테스트 진행

## 🔍 작업 상세
- [ ] Product(상품) 엔티티 생성 및 ERD 기반 필드 구성
- [ ] Market / Center 엔티티와 연관관계 설정
- [ ] POST /api/markets/{marketId}/products 가게 상품 등록 로직 구현


## 🧪 테스트 결과
- [ ] 로컬 테스트 완료
<img width="399" height="526" alt="물품 등록 API 예시" src="https://github.com/user-attachments/assets/71b02703-1b1c-450b-879f-8c2391485cf7" />
<img width="2310" height="1320" alt="DB1" src="https://github.com/user-attachments/assets/20cd3814-ae39-4fdd-9fa0-a39e8b691642" />


## 🗨 기타 참고 사항
- 이슈 번호: `#6`
- 이미지를 프론트에서 처리하고 서버는 URL만 처리하는 방식을 사용했습니다
- 유통기한은 상품 설명에 쓰는 걸로, 따로 넣진 않았습니다.
- 저는 요청값으로 marketId를 사용합니다.
