### PR TITLE
feat: 공공데이터 기반 복지시설 검증 및 예약 로직 연동

### DIFF
--- a/src/main/java/com/example/ganzi6/api/verification/CenterVerificationService.java
+++ b/src/main/java/com/example/ganzi6/api/verification/CenterVerificationService.java
@@ -1,0 +1,35 @@
+package com.example.ganzi6.api.verification;
+
+import com.example.ganzi6.domain.center.Center.Center;
+import com.example.ganzi6.domain.center.CenterRepository.CenterRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CenterVerificationService {
+
+    private final CenterRepository centerRepository;
+    private final SafetyDataClient safetyDataClient;
+
+    @Transactional
+    public void verifyCenterIfNeeded(Long centerId) {
+        Center center = centerRepository.findById(centerId)
+                .orElseThrow(() -> new IllegalArgumentException("센터를 찾을 수 없습니다."));
+
+        // 이미 검증된 센터면 그냥 통과
+        if (center.isVerified()) {
+            return;
+        }
+
+        boolean exists = safetyDataClient.existsFacility(center.getName());
+        if (!exists) {
+            // 공공데이터에 없으면 예약 막기
+            throw new IllegalStateException("공공데이터에 없는 복지시설이라 예약이 불가합니다.");
+        }
+
+        // 공공데이터에 존재 → 검증 상태로 변경
+        center.verify();
+    }
+}

--- a/src/main/java/com/example/ganzi6/api/verification/SafetyDataClient.java
+++ b/src/main/java/com/example/ganzi6/api/verification/SafetyDataClient.java
@@ -1,0 +1,62 @@
+package com.example.ganzi6.api.verification;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SafetyDataClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${safetydata.base-url}")
+    private String baseUrl;
+
+    @Value("${safetydata.service-key}")
+    private String serviceKey;
+
+    public boolean existsFacility(String facilityName) {
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .queryParam("serviceKey", serviceKey)
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", 1000)   // 넉넉하게
+                .queryParam("returnType", "json");
+
+        String url = builder.toUriString();
+        log.info("🔎 SafetyData 요청 URL = {}", url);
+
+        ResponseEntity<String> response =
+                restTemplate.getForEntity(url, String.class);
+
+        log.info("HTTP 상태코드 = {}", response.getStatusCode());
+
+        String body = response.getBody();
+        if (body == null) {
+            log.warn("SafetyData 응답 body가 null입니다.");
+            return false;
+        }
+
+        // IP 에러 방어 (혹시 또 바뀌었을 때)
+        if (body.contains("UNREGISTERED IP ERROR")) {
+            log.warn("공공데이터 IP 미등록 오류 발생. body={}", body);
+            return false;
+        }
+
+        // 공백 제거해서 비교 (body 쪽은 공백 거의 없지만 그냥 통일)
+        String normalizedInput = facilityName.replaceAll("\\s+", "");
+        String normalizedBody  = body.replaceAll("\\s+", "");
+
+        boolean found = normalizedBody.contains(normalizedInput);
+
+        log.info("🔍 검증할 센터명 = {}, 결과(found) = {}", normalizedInput, found);
+        return found;
+    }
+}

--- a/src/main/java/com/example/ganzi6/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/ganzi6/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.example.ganzi6.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}
+

--- a/src/main/java/com/example/ganzi6/domain/center/Center/Center.java
+++ b/src/main/java/com/example/ganzi6/domain/center/Center/Center.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -23,6 +24,8 @@ public class Center {
 
     private String name;
     private String address;
+
+    private boolean verified; // 공공데이터 검증 여부 (검증내역값)
 
     @Column(length = 200)
     private String description;
@@ -38,5 +41,9 @@ public class Center {
 
     @OneToMany(mappedBy = "center", cascade = CascadeType.ALL, orphanRemoval = false)
     private List<Reservation> reservations = new ArrayList<>();
+
+    public void verify() {
+        this.verified = true;
+    }
 }
 


### PR DESCRIPTION
rleated to #2

## 📌 작업 내용
공공데이터(SafetyData) 기반 복지시설 검증 기능을 추가하고  
예약 생성 시 해당 검증을 자동으로 수행하도록 연동했습니다

## 🔍 작업 상세
- [x] SafetyData API 호출용 SafetyDataClient 구현  
- [x] center.verify() 도입 및 Center 엔티티에 verified(Boolean) 필드 추가 
- [x] CenterVerificationService 구현  
  - DB에 미검증 센터가 예약 시도 → 공공데이터 검색  
  - 일치 시 verified=true 저장  
  - 미일치 시 예외 발생   
- [x] MakeReservation 이전에 검증 흐름 자동으로 타도록 Controller에서 호출
- [x] 검증 성공 후 재요청 시 API 불필요 호출 방지 (캐싱 효과)

## 🧪 테스트 결과
- [x] 로컬 테스트 완료

## 🗨 기타 참고 사항
- 이슈 번호: #2 
